### PR TITLE
Added 'progLabels' and 'finalText'

### DIFF
--- a/lib/cool_stepper.dart
+++ b/lib/cool_stepper.dart
@@ -21,11 +21,7 @@ class CoolStepper extends StatefulWidget {
     @required this.onCompleted,
     this.contentPadding = const EdgeInsets.symmetric(horizontal: 20.0),
     this.config = const CoolStepperConfig(
-      backText: "BACK",
-      nextText: "NEXT",
-      stepText: "STEP",
-      ofText: "OF",
-    ),
+        backText: "PREV", nextText: "NEXT", stepText: "STEP", ofText: "OF", finalText: "FINISH", progLabels: null),
   }) : super(key: key);
 
   @override
@@ -111,6 +107,35 @@ class _CoolStepperState extends State<CoolStepper> {
       ),
     );
 
+    String getNextLabel() {
+      String nextLabel;
+      if (widget.config.progLabels != null) {
+        if (_isLast(currentStep)) {
+          nextLabel = widget.config.finalText ?? 'FINISH';
+        } else {
+          nextLabel = widget.config.progLabels[currentStep + 1];
+        }
+      } else {
+        nextLabel = widget.config.nextText ?? 'NEXT';
+      }
+      return nextLabel;
+    }
+
+    String getPrevLabel() {
+      String backLabel;
+      if (widget.config.progLabels != null) {
+        if (_isFirst(currentStep)) {
+          backLabel = '';
+        } else {
+          backLabel = widget.config.progLabels[currentStep - 1];
+        }
+      } else {
+        backLabel = widget.config.backText ?? 'PREV';
+      }
+
+      return backLabel;
+    }
+
     final buttons = Container(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -118,7 +143,7 @@ class _CoolStepperState extends State<CoolStepper> {
           FlatButton(
             onPressed: onStepBack,
             child: Text(
-              widget.config.backText ?? "BACK",
+              getPrevLabel(),
               style: TextStyle(color: Colors.grey),
             ),
           ),
@@ -126,7 +151,7 @@ class _CoolStepperState extends State<CoolStepper> {
           FlatButton(
             onPressed: onStepNext,
             child: Text(
-              widget.config.nextText ?? "NEXT",
+              getNextLabel(),
               style: TextStyle(
                 color: Colors.green,
               ),

--- a/lib/src/models/cool_stepper_config.dart
+++ b/lib/src/models/cool_stepper_config.dart
@@ -38,15 +38,24 @@ class CoolStepperConfig {
   /// This is the textStyle for the subtitle text
   final TextStyle subtitleTextStyle;
 
-  const CoolStepperConfig({
-    this.backText,
-    this.nextText,
-    this.stepText,
-    this.ofText,
-    this.headerColor,
-    this.iconColor,
-    this.icon,
-    this.titleTextStyle,
-    this.subtitleTextStyle,
-  });
+  /// Progress labels that when supplied will override 'backText' and 'nextText', must equal the number of steps
+  final List<String> progLabels;
+
+  /// The text that should be displayed for the next button on the final step
+  ///
+  /// default is 'FINISH'
+  final String finalText;
+
+  const CoolStepperConfig(
+      {this.backText,
+      this.nextText,
+      this.stepText,
+      this.ofText,
+      this.headerColor,
+      this.iconColor,
+      this.icon,
+      this.titleTextStyle,
+      this.subtitleTextStyle,
+      this.progLabels,
+      this.finalText});
 }


### PR DESCRIPTION
Added 'progLabels' and 'finalText'

'progLabels' is an array of strings that replace the next and back button's text as the user progresses, if this config is provided it overrides the defaults and/or 'backText'/'nextText' configs, defaults to null. The number of steps must equal the number of 'progLabels' strings, each label corresponds to each step under the same index.

'finalText' is the text that the next button will have on the final step, default to 'FINISH'