### PR TITLE
Use spacer in title row

### DIFF
--- a/lib/src/widgets/cool_stepper_view.dart
+++ b/lib/src/widgets/cool_stepper_view.dart
@@ -35,7 +35,6 @@ class CoolStepperView extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
               Container(
-                width: MediaQuery.of(context).size.width * 0.8,
                 child: Text(
                   step.title.toUpperCase(),
                   style: config.titleTextStyle ??
@@ -47,7 +46,7 @@ class CoolStepperView extends StatelessWidget {
                   maxLines: 2,
                 ),
               ),
-              SizedBox(width: 5.0),
+              Spacer(),
               Visibility(
                   visible: config.icon == null,
                   child: Icon(


### PR DESCRIPTION
Hi,
I have a layout issue using your wizzard (cool project!). I debugged into it and it seems that the width calculation of the title is causing the problem. I think you can easily use a Spacer() in the header row. It renders the same way but removes the layout problem on my setup.

![image](https://user-images.githubusercontent.com/16028898/103135950-84c17900-46bc-11eb-9e65-a32cd4d33fa0.png)
