### PR TITLE
Added support for async validations.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,14 +28,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -129,14 +129,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -253,7 +253,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -267,7 +267,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -283,5 +283,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/lib/cool_stepper.dart
+++ b/lib/cool_stepper.dart
@@ -72,8 +72,8 @@ class _CoolStepperState extends State<CoolStepper> {
     return widget.steps.length - 1 == index;
   }
 
-  void onStepNext() {
-    final validation = widget.steps[currentStep].validation!();
+  Future<void> onStepNext() async {
+    final validation = await widget.steps[currentStep].validation!();
 
     /// [validation] is null, no validation rule
     if (validation == null) {
@@ -82,7 +82,7 @@ class _CoolStepperState extends State<CoolStepper> {
           currentStep++;
         });
         FocusScope.of(context).unfocus();
-        switchToPage(currentStep);
+        await switchToPage(currentStep);
       } else {
         widget.onCompleted();
       }
@@ -102,7 +102,7 @@ class _CoolStepperState extends State<CoolStepper> {
           duration: Duration(seconds: 2),
           leftBarIndicatorColor: Theme.of(context).primaryColor,
         );
-        flush.show(context);
+        await flush.show(context);
 
         // final snackBar = SnackBar(content: Text(validation));
         // ScaffoldMessenger.of(context).showSnackBar(snackBar);

--- a/lib/src/models/cool_step.dart
+++ b/lib/src/models/cool_step.dart
@@ -1,10 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 
 class CoolStep {
   final String title;
   final String subtitle;
   final Widget content;
-  final String? Function()? validation;
+  final FutureOr<String?> Function()? validation;
   final bool isHeaderEnabled;
 
   CoolStep({

--- a/lib/src/widgets/cool_stepper_view.dart
+++ b/lib/src/widgets/cool_stepper_view.dart
@@ -1,5 +1,4 @@
 import 'package:cool_stepper/cool_stepper.dart';
-import 'package:cool_stepper/src/models/cool_step.dart';
 import 'package:flutter/material.dart';
 
 class CoolStepperView extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,14 +28,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,14 +73,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -155,6 +155,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
I added support for async validations changing the validation attribute from a String? Function()? to a FutureOr<String?> Function()?.

Why?

I need to make more complex validations that would take longer (e.g. API calls and database queries) so I could not make it without returning a Future.

This should not be a breaking change, everything just worked out of box after changing that.