### PR TITLE
Disable next button and show loading indicator when isNextButtonLoading is set to true

### DIFF
--- a/lib/cool_stepper.dart
+++ b/lib/cool_stepper.dart
@@ -188,8 +188,21 @@ class _CoolStepperState extends State<CoolStepper> {
         ),
         counter,
         TextButton(
-          onPressed: onStepNext,
-          child: Text(
+          onPressed: widget.config.isNextButtonLoading ? null : onStepNext,
+          child: widget.config.isNextButtonLoading
+                ? const SizedBox(
+                    height: 30,
+                    width: 30,
+                    child: Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(8.0),
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                        ),
+                      ),
+                    ),
+                  )
+                : Text(
             getNextLabel(),
             style: const TextStyle(
               color: Colors.green,

--- a/lib/src/models/cool_stepper_config.dart
+++ b/lib/src/models/cool_stepper_config.dart
@@ -55,6 +55,10 @@ class CoolStepperConfig {
 
   final bool isHeaderEnabled;
 
+  /// This can be set to True when you'd like to disable the next button
+  /// and show a circular progress indicator in the button
+  final bool isNextButtonLoading;
+
   const CoolStepperConfig({
     this.backText = 'PRE',
     this.nextText = 'NEXT',
@@ -69,5 +73,6 @@ class CoolStepperConfig {
     this.nextTextList,
     this.finalText = 'FINISH',
     this.isHeaderEnabled = true,
+    this.isNextButtonLoading = false,
   });
 }


### PR DESCRIPTION
I've created a config variable isNextButtonLoading which can be set to true to disable the button and show a circular progress indicator. This can be useful during a network request when submit button is pressed.